### PR TITLE
Fix "This container does not reference a native integer"

### DIFF
--- a/lib/Data/TextOrBinary.pm6
+++ b/lib/Data/TextOrBinary.pm6
@@ -9,7 +9,7 @@ multi is-text(Blob $content, Int(Cool) :$test-bytes = 4096) is export {
     my int $printable;
     my int $unprintable;
     loop (my int $i = 0; $i < $limit; $i++) {
-        my int $check = $content[$i];
+        my uint $check = $content[$i];
         if $check == 0 {
             # NULL byte, so binary.
             return False;


### PR DESCRIPTION
Reading files gives `Blob[uint8]` so we need to use a matching type
when assigning an element to a natively typed variable.

If is-text should also work with signed Blobs, the alternative would be to just
remove the type altogether or provide multi candidates for both SignedBlob
and UnsignedBlob (which however only exist on the newest Rakudo)